### PR TITLE
General - Lowercase addon names and pboprefixes

### DIFF
--- a/addons/compat_optre/$PBOPREFIX$
+++ b/addons/compat_optre/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aftb\addons\optre
+z\aftb\addons\compat_optre

--- a/addons/compat_optre_fc/$PBOPREFIX$
+++ b/addons/compat_optre_fc/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aftb\addons\optre_fc
+z\aftb\addons\compat_optre_fc

--- a/addons/loadorder/$PBOPREFIX$
+++ b/addons/loadorder/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aftb\addons\loadOrder
+z\aftb\addons\loadorder

--- a/addons/loadorder/script_component.hpp
+++ b/addons/loadorder/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT loadOrder
+#define COMPONENT loadorder
 #define COMPONENT_BEAUTIFIED Load Order
 #include "\z\aftb\addons\main\script_mod.hpp"
 

--- a/addons/staticline/script_component.hpp
+++ b/addons/staticline/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT staticLine
+#define COMPONENT staticline
 #define COMPONENT_BEAUTIFIED Static Line
 #include "\z\aftb\addons\main\script_mod.hpp"
 

--- a/extra/example_addon/$PBOPREFIX$
+++ b/extra/example_addon/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\aftb\addons\addonName
+z\aftb\addons\addonname

--- a/extra/example_addon/script_component.hpp
+++ b/extra/example_addon/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT addonName
+#define COMPONENT addonname
 #define COMPONENT_BEAUTIFIED Addon Name
 #include "\z\aftb\addons\main\script_mod.hpp"
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing `compat_` from OPTRE / OPTRE FC compat addons in `$PBOPREFIX$`
- Lowercase `COMPONENT` names and names in `$PBOPREFIX$`s

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartRuffian/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartRuffian/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None